### PR TITLE
feat: pharmacophore-based active/decoy discrimination

### DIFF
--- a/discriminate.py
+++ b/discriminate.py
@@ -8,6 +8,7 @@ cosine similarity. Outputs ranked conformations with ROC-AUC, EF1%, and EF5%.
 """
 
 import os
+import logging
 import numpy as np
 import pandas as pd
 from sklearn.metrics import roc_auc_score
@@ -34,7 +35,21 @@ _RDKIT_FEATURE_MAP = {
 }
 
 _FDEF_PATH = os.path.join(RDConfig.RDDataDir, 'BaseFeatures.fdef')
-_FACTORY = ChemicalFeatures.BuildFeatureFactory(_FDEF_PATH)
+_factory_instance = None
+
+_logger = logging.getLogger(__name__)
+
+
+def _get_factory():
+    global _factory_instance
+    if _factory_instance is None:
+        if not os.path.exists(_FDEF_PATH):
+            raise RuntimeError(
+                f"RDKit feature definition file not found: {_FDEF_PATH}. "
+                "Ensure rdkit data files are installed (e.g. conda install -c conda-forge rdkit)."
+            )
+        _factory_instance = ChemicalFeatures.BuildFeatureFactory(_FDEF_PATH)
+    return _factory_instance
 
 
 def _extract_resname(residue_id: str) -> str:
@@ -43,8 +58,15 @@ def _extract_resname(residue_id: str) -> str:
         clean = part.strip().upper()
         if len(clean) == 3 and clean.isalpha():
             return clean
+    # Fallback: expected format is CHAIN_NUM_RESNAME (e.g. 'A_1_ALA')
     alpha = ''.join(c for c in residue_id if c.isalpha())
-    return alpha[:3].upper() if len(alpha) >= 3 else ''
+    result = alpha[:3].upper() if len(alpha) >= 3 else ''
+    if result:
+        _logger.warning(
+            "Residue ID '%s' did not match expected CHAIN_NUM_RESNAME format; "
+            "extracted '%s' via fallback heuristic.", residue_id, result
+        )
+    return result
 
 
 def get_pocket_features(residue_ids: list) -> dict:
@@ -73,14 +95,14 @@ def get_ligand_features(mol) -> dict:
     if mol is None:
         return features
     try:
-        feats = _FACTORY.GetFeaturesForMol(mol)
+        feats = _get_factory().GetFeaturesForMol(mol)
         for feat in feats:
             family = feat.GetFamily()
             key = _RDKIT_FEATURE_MAP.get(family)
             if key:
                 features[key] += 1
-    except Exception:
-        pass
+    except Exception as exc:
+        _logger.warning("Failed to extract features from molecule: %s", exc)
     return features
 
 
@@ -162,7 +184,7 @@ def run_discrimination(cluster_dir: str, actives_sdf: str, decoys_sdf: str,
         residue_ids = [r for r in str(rep['residues']).split() if r]
         pocket_feats = get_pocket_features(residue_ids)
         scores_actives = [score_complementarity(pocket_feats, lf) for lf in active_features]
-        scores_decoys = [score_complementarity(pocket_feats, df) for df in decoy_features]
+        scores_decoys = [score_complementarity(pocket_feats, decoy_feat) for decoy_feat in decoy_features]
         metrics = compute_discrimination_metrics(scores_actives, scores_decoys)
         rows.append({
             'cluster_id': rep.get('cluster', ''),

--- a/discriminate.py
+++ b/discriminate.py
@@ -133,8 +133,13 @@ def run_discrimination(cluster_dir: str, actives_sdf: str, decoys_sdf: str,
         raise FileNotFoundError(f"cluster_representatives.csv not found in {cluster_dir}")
 
     df_reps = pd.read_csv(reps_csv)
-    if 'residues' not in df_reps.columns:
-        raise ValueError("cluster_representatives.csv must contain a 'residues' column")
+    required_cols = {'residues', 'cluster', 'Frame'}
+    missing_cols = required_cols - set(df_reps.columns)
+    if missing_cols:
+        raise ValueError(
+            f"cluster_representatives.csv is missing required columns: {missing_cols}. "
+            f"Found columns: {list(df_reps.columns)}"
+        )
 
     actives = _load_mols_from_sdf(actives_sdf)
     decoys = _load_mols_from_sdf(decoys_sdf)

--- a/discriminate.py
+++ b/discriminate.py
@@ -107,7 +107,26 @@ def get_ligand_features(mol) -> dict:
 
 
 def score_complementarity(pocket_features: dict, ligand_features: dict) -> float:
-    p = np.array([pocket_features[k] for k in FEATURE_KEYS], dtype=float)
+    """
+    Compute pharmacophoric complementarity between a pocket and a ligand.
+
+    H-bond and charge features are cross-mapped (pocket donor pairs with ligand
+    acceptor, pocket acceptor pairs with ligand donor, etc.). Hydrophobic and
+    aromatic features are self-complementary (like pairs with like).
+
+    Returns a float in [0, 1]: 1 means perfect complementarity, 0 means no
+    complementary features. Returns 0.0 if either vector is all zeros.
+    """
+    # Remap pocket features to their complementary counterparts
+    complementary_pocket = {
+        'donor':       pocket_features['acceptor'],    # pocket acceptor pairs with ligand donor
+        'acceptor':    pocket_features['donor'],       # pocket donor pairs with ligand acceptor
+        'hydrophobic': pocket_features['hydrophobic'], # self-complementary
+        'aromatic':    pocket_features['aromatic'],    # self-complementary (pi-stacking)
+        'positive':    pocket_features['negative'],    # pocket negative pairs with ligand positive
+        'negative':    pocket_features['positive'],    # pocket positive pairs with ligand negative
+    }
+    p = np.array([complementary_pocket[k] for k in FEATURE_KEYS], dtype=float)
     l = np.array([ligand_features[k] for k in FEATURE_KEYS], dtype=float)
     norm_p = np.linalg.norm(p)
     norm_l = np.linalg.norm(l)

--- a/discriminate.py
+++ b/discriminate.py
@@ -1,0 +1,174 @@
+"""
+discriminate.py — Pharmacophore-based active/decoy discrimination.
+
+Given a pocket_clusters directory (output of cluster_pockets) and two SDF files
+(actives and decoys), scores each cluster representative by its ability to
+discriminate actives from decoys using residue-based pharmacophore vectors and
+cosine similarity. Outputs ranked conformations with ROC-AUC, EF1%, and EF5%.
+"""
+
+import os
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+from rdkit import Chem, RDConfig
+from rdkit.Chem import ChemicalFeatures
+
+FEATURE_KEYS = ['donor', 'acceptor', 'hydrophobic', 'aromatic', 'positive', 'negative']
+
+_DONOR_RESNAMES = {'SER', 'THR', 'TYR', 'ASN', 'GLN', 'LYS', 'ARG', 'HIS', 'TRP'}
+_ACCEPTOR_RESNAMES = {'ASP', 'GLU', 'ASN', 'GLN', 'SER', 'THR', 'TYR', 'HIS'}
+_HYDROPHOBIC_RESNAMES = {'ALA', 'VAL', 'ILE', 'LEU', 'MET', 'PHE', 'TRP', 'PRO'}
+_AROMATIC_RESNAMES = {'PHE', 'TRP', 'TYR', 'HIS'}
+_POSITIVE_RESNAMES = {'LYS', 'ARG', 'HIS'}
+_NEGATIVE_RESNAMES = {'ASP', 'GLU'}
+
+_RDKIT_FEATURE_MAP = {
+    'Donor': 'donor',
+    'Acceptor': 'acceptor',
+    'Hydrophobe': 'hydrophobic',
+    'LumpedHydrophobe': 'hydrophobic',
+    'Aromatic': 'aromatic',
+    'PosIonizable': 'positive',
+    'NegIonizable': 'negative',
+}
+
+_FDEF_PATH = os.path.join(RDConfig.RDDataDir, 'BaseFeatures.fdef')
+_FACTORY = ChemicalFeatures.BuildFeatureFactory(_FDEF_PATH)
+
+
+def _extract_resname(residue_id: str) -> str:
+    parts = residue_id.strip().split('_')
+    for part in reversed(parts):
+        clean = part.strip().upper()
+        if len(clean) == 3 and clean.isalpha():
+            return clean
+    alpha = ''.join(c for c in residue_id if c.isalpha())
+    return alpha[:3].upper() if len(alpha) >= 3 else ''
+
+
+def get_pocket_features(residue_ids: list) -> dict:
+    features = {k: 0 for k in FEATURE_KEYS}
+    for rid in residue_ids:
+        resname = _extract_resname(rid)
+        if not resname:
+            continue
+        if resname in _DONOR_RESNAMES:
+            features['donor'] += 1
+        if resname in _ACCEPTOR_RESNAMES:
+            features['acceptor'] += 1
+        if resname in _HYDROPHOBIC_RESNAMES:
+            features['hydrophobic'] += 1
+        if resname in _AROMATIC_RESNAMES:
+            features['aromatic'] += 1
+        if resname in _POSITIVE_RESNAMES:
+            features['positive'] += 1
+        if resname in _NEGATIVE_RESNAMES:
+            features['negative'] += 1
+    return features
+
+
+def get_ligand_features(mol) -> dict:
+    features = {k: 0 for k in FEATURE_KEYS}
+    if mol is None:
+        return features
+    try:
+        feats = _FACTORY.GetFeaturesForMol(mol)
+        for feat in feats:
+            family = feat.GetFamily()
+            key = _RDKIT_FEATURE_MAP.get(family)
+            if key:
+                features[key] += 1
+    except Exception:
+        pass
+    return features
+
+
+def score_complementarity(pocket_features: dict, ligand_features: dict) -> float:
+    p = np.array([pocket_features[k] for k in FEATURE_KEYS], dtype=float)
+    l = np.array([ligand_features[k] for k in FEATURE_KEYS], dtype=float)
+    norm_p = np.linalg.norm(p)
+    norm_l = np.linalg.norm(l)
+    if norm_p == 0 or norm_l == 0:
+        return 0.0
+    return float(np.dot(p, l) / (norm_p * norm_l))
+
+
+def _enrichment_factor(scores_actives: list, scores_decoys: list, fraction: float) -> float:
+    n_actives = len(scores_actives)
+    n_total = n_actives + len(scores_decoys)
+    n_top = max(1, int(fraction * n_total))
+    all_scores = [(s, 1) for s in scores_actives] + [(s, 0) for s in scores_decoys]
+    all_scores.sort(key=lambda x: -x[0])
+    actives_in_top = sum(label for _, label in all_scores[:n_top])
+    expected = fraction * n_actives
+    if expected == 0:
+        return 0.0
+    return float(actives_in_top / expected)
+
+
+def compute_discrimination_metrics(scores_actives: list, scores_decoys: list) -> dict:
+    labels = [1] * len(scores_actives) + [0] * len(scores_decoys)
+    scores = list(scores_actives) + list(scores_decoys)
+    try:
+        roc_auc = float(roc_auc_score(labels, scores))
+    except ValueError:
+        roc_auc = 0.5
+    ef1 = _enrichment_factor(scores_actives, scores_decoys, 0.01)
+    ef5 = _enrichment_factor(scores_actives, scores_decoys, 0.05)
+    return {'roc_auc': roc_auc, 'ef1': ef1, 'ef5': ef5}
+
+
+def _load_mols_from_sdf(sdf_path: str) -> list:
+    supplier = Chem.SDMolSupplier(sdf_path, removeHs=False)
+    return [mol for mol in supplier if mol is not None]
+
+
+def run_discrimination(cluster_dir: str, actives_sdf: str, decoys_sdf: str,
+                       outfolder: str) -> pd.DataFrame:
+    os.makedirs(outfolder, exist_ok=True)
+
+    reps_csv = os.path.join(cluster_dir, 'cluster_representatives.csv')
+    if not os.path.exists(reps_csv):
+        raise FileNotFoundError(f"cluster_representatives.csv not found in {cluster_dir}")
+
+    df_reps = pd.read_csv(reps_csv)
+    if 'residues' not in df_reps.columns:
+        raise ValueError("cluster_representatives.csv must contain a 'residues' column")
+
+    actives = _load_mols_from_sdf(actives_sdf)
+    decoys = _load_mols_from_sdf(decoys_sdf)
+
+    if not actives:
+        raise ValueError(f"No valid molecules loaded from actives SDF: {actives_sdf}")
+    if not decoys:
+        raise ValueError(f"No valid molecules loaded from decoys SDF: {decoys_sdf}")
+
+    if len(actives) > 200:
+        raise ValueError(f"Too many actives: {len(actives)} (max 200)")
+    if len(decoys) > 2000:
+        raise ValueError(f"Too many decoys: {len(decoys)} (max 2000)")
+
+    active_features = [get_ligand_features(mol) for mol in actives]
+    decoy_features = [get_ligand_features(mol) for mol in decoys]
+
+    rows = []
+    for _, rep in df_reps.iterrows():
+        residue_ids = [r for r in str(rep['residues']).split() if r]
+        pocket_feats = get_pocket_features(residue_ids)
+        scores_actives = [score_complementarity(pocket_feats, lf) for lf in active_features]
+        scores_decoys = [score_complementarity(pocket_feats, df) for df in decoy_features]
+        metrics = compute_discrimination_metrics(scores_actives, scores_decoys)
+        rows.append({
+            'cluster_id': rep.get('cluster', ''),
+            'frame': rep.get('Frame', ''),
+            'roc_auc': round(metrics['roc_auc'], 4),
+            'ef1': round(metrics['ef1'], 4),
+            'ef5': round(metrics['ef5'], 4),
+            'residues': rep['residues'],
+            'probability': rep.get('probability', ''),
+        })
+
+    df_results = pd.DataFrame(rows).sort_values('roc_auc', ascending=False).reset_index(drop=True)
+    df_results.to_csv(os.path.join(outfolder, 'discrimination_results.csv'), index=False)
+    return df_results

--- a/pockethunter.py
+++ b/pockethunter.py
@@ -4,9 +4,10 @@ import uuid
 from datetime import datetime
 import logging
 from logging.handlers import RotatingFileHandler
-import extract_predict  
+import extract_predict
 import cluster
 import plot
+import discriminate
 
 def setup_logging(log_file):
     """
@@ -153,10 +154,23 @@ def cluster_pockets(args, config):
 def plot_clustermap(args):
     """Generate cluster map visualization from clustering results."""
     infolder = os.path.abspath(args.infolder)
-    
+
     plot.plot_clustermap(
         infolder=infolder
     )
+
+def discriminate_conformations(args, config):
+    """Rank cluster representatives by active/decoy discrimination."""
+    logger = config['logger']
+    logger.info("Starting discrimination analysis.")
+    df = discriminate.run_discrimination(
+        cluster_dir=os.path.abspath(args.cluster_dir),
+        actives_sdf=os.path.abspath(args.actives),
+        decoys_sdf=os.path.abspath(args.decoys),
+        outfolder=os.path.abspath(args.outfolder),
+    )
+    logger.info("Discrimination complete. Results saved to %s", args.outfolder)
+    logger.info("\n%s", df[['cluster_id', 'frame', 'roc_auc', 'ef1', 'ef5']].to_string(index=False))
 
 def main():
     # Initialize argument parser
@@ -220,6 +234,32 @@ def main():
     parser_plot = subparsers.add_parser("plot_clustermap", help="Generate cluster map visualization from clustering results.")
     parser_plot.add_argument("--infolder", type=str, help='Input folder containing clustering results (output from cluster_pockets).')
 
+    # Discrimination analysis
+    parser_disc = subparsers.add_parser(
+        "discriminate",
+        help="Rank cluster representatives by active/decoy pharmacophore discrimination."
+    )
+    parser_disc.add_argument(
+        "--cluster_dir", required=True,
+        help="Path to pocket_clusters output directory (contains cluster_representatives.csv)."
+    )
+    parser_disc.add_argument(
+        "--actives", required=True,
+        help="Path to actives SDF file (max 200 molecules)."
+    )
+    parser_disc.add_argument(
+        "--decoys", required=True,
+        help="Path to decoys SDF file (max 2000 molecules)."
+    )
+    parser_disc.add_argument(
+        "--outfolder", required=True,
+        help="Output folder for discrimination results."
+    )
+    parser_disc.add_argument(
+        "--overwrite", action='store_true',
+        help="Overwrite existing output directory."
+    )
+
     args = parser.parse_args()
 
     if args.command is None:
@@ -241,6 +281,8 @@ def main():
         cluster_pockets(args, config)
     elif args.command == "plot_clustermap":
         plot_clustermap(args)
+    elif args.command == "discriminate":
+        discriminate_conformations(args, config)
     else:
         parser.print_help()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ numpy
 nglview
 mdtraj
 scikit-learn
+rdkit

--- a/tests/test_discriminate.py
+++ b/tests/test_discriminate.py
@@ -1,0 +1,125 @@
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from discriminate import (
+    get_pocket_features,
+    get_ligand_features,
+    score_complementarity,
+    compute_discrimination_metrics,
+    FEATURE_KEYS,
+)
+
+
+def test_get_pocket_features_returns_all_keys():
+    features = get_pocket_features(['A_1_ALA'])
+    assert set(features.keys()) == set(FEATURE_KEYS)
+
+def test_get_pocket_features_hydrophobic():
+    features = get_pocket_features(['A_1_ALA', 'A_2_VAL'])
+    assert features['hydrophobic'] == 2
+
+def test_get_pocket_features_donor():
+    features = get_pocket_features(['A_1_ARG'])
+    assert features['donor'] >= 1
+
+def test_get_pocket_features_acceptor():
+    features = get_pocket_features(['A_1_ASP'])
+    assert features['acceptor'] >= 1
+
+def test_get_pocket_features_aromatic():
+    features = get_pocket_features(['A_1_PHE'])
+    assert features['aromatic'] >= 1
+
+def test_get_pocket_features_positive():
+    features = get_pocket_features(['A_1_LYS'])
+    assert features['positive'] >= 1
+
+def test_get_pocket_features_negative():
+    features = get_pocket_features(['A_1_GLU'])
+    assert features['negative'] >= 1
+
+def test_get_pocket_features_empty():
+    features = get_pocket_features([])
+    assert all(v == 0 for v in features.values())
+
+def test_get_pocket_features_unknown_residue():
+    features = get_pocket_features(['A_1_UNK'])
+    assert all(v >= 0 for v in features.values())
+
+def test_get_ligand_features_returns_all_keys():
+    from rdkit import Chem
+    mol = Chem.MolFromSmiles('c1ccccc1')
+    mol = Chem.AddHs(mol)
+    features = get_ligand_features(mol)
+    assert set(features.keys()) == set(FEATURE_KEYS)
+
+def test_get_ligand_features_aromatic_benzene():
+    from rdkit import Chem
+    mol = Chem.MolFromSmiles('c1ccccc1')
+    mol = Chem.AddHs(mol)
+    features = get_ligand_features(mol)
+    assert features['aromatic'] >= 1
+
+def test_get_ligand_features_donor_ethanol():
+    from rdkit import Chem
+    mol = Chem.MolFromSmiles('CCO')
+    mol = Chem.AddHs(mol)
+    features = get_ligand_features(mol)
+    assert features['donor'] >= 1
+
+def test_get_ligand_features_none_mol():
+    features = get_ligand_features(None)
+    assert all(v == 0 for v in features.values())
+
+def test_score_complementarity_identical_vectors():
+    pocket = {'donor': 2, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    ligand = {'donor': 2, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    score = score_complementarity(pocket, ligand)
+    assert score == pytest.approx(1.0)
+
+def test_score_complementarity_orthogonal_vectors():
+    pocket = {'donor': 1, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    ligand = {'donor': 0, 'acceptor': 1, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    score = score_complementarity(pocket, ligand)
+    assert score == pytest.approx(0.0)
+
+def test_score_complementarity_zero_pocket():
+    pocket = {k: 0 for k in FEATURE_KEYS}
+    ligand = {'donor': 1, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    score = score_complementarity(pocket, ligand)
+    assert score == pytest.approx(0.0)
+
+def test_score_complementarity_range():
+    pocket = {'donor': 2, 'acceptor': 1, 'hydrophobic': 3, 'aromatic': 1, 'positive': 0, 'negative': 0}
+    ligand = {'donor': 1, 'acceptor': 2, 'hydrophobic': 1, 'aromatic': 0, 'positive': 1, 'negative': 0}
+    score = score_complementarity(pocket, ligand)
+    assert 0.0 <= score <= 1.0
+
+def test_compute_metrics_perfect_discrimination():
+    scores_actives = [1.0, 0.9, 0.8]
+    scores_decoys = [0.3, 0.2, 0.1]
+    metrics = compute_discrimination_metrics(scores_actives, scores_decoys)
+    assert metrics['roc_auc'] == pytest.approx(1.0)
+
+def test_compute_metrics_random_discrimination():
+    import random
+    random.seed(42)
+    scores_actives = [random.random() for _ in range(100)]
+    scores_decoys = [random.random() for _ in range(100)]
+    metrics = compute_discrimination_metrics(scores_actives, scores_decoys)
+    assert 0.0 <= metrics['roc_auc'] <= 1.0
+
+def test_compute_metrics_keys_present():
+    metrics = compute_discrimination_metrics([0.9, 0.8], [0.2, 0.1])
+    assert 'roc_auc' in metrics
+    assert 'ef1' in metrics
+    assert 'ef5' in metrics
+
+def test_compute_metrics_ef1_perfect():
+    scores_actives = [1.0] * 10
+    scores_decoys = [0.0] * 90
+    metrics = compute_discrimination_metrics(scores_actives, scores_decoys)
+    assert metrics['ef1'] > 1.0

--- a/tests/test_discriminate.py
+++ b/tests/test_discriminate.py
@@ -9,6 +9,7 @@ from discriminate import (
     get_ligand_features,
     score_complementarity,
     compute_discrimination_metrics,
+    run_discrimination,
     FEATURE_KEYS,
 )
 
@@ -123,3 +124,15 @@ def test_compute_metrics_ef1_perfect():
     scores_decoys = [0.0] * 90
     metrics = compute_discrimination_metrics(scores_actives, scores_decoys)
     assert metrics['ef1'] > 1.0
+
+def test_run_discrimination_missing_columns(tmp_path):
+    import pandas as pd
+    # CSV missing 'cluster' column
+    bad_csv = tmp_path / "cluster_representatives.csv"
+    pd.DataFrame({'residues': ['A_1_ALA'], 'Frame': [1]}).to_csv(bad_csv, index=False)
+    actives_sdf = tmp_path / "actives.sdf"
+    actives_sdf.write_text("")
+    decoys_sdf = tmp_path / "decoys.sdf"
+    decoys_sdf.write_text("")
+    with pytest.raises(ValueError, match="missing required columns"):
+        run_discrimination(str(tmp_path), str(actives_sdf), str(decoys_sdf), str(tmp_path / "out"))

--- a/tests/test_discriminate.py
+++ b/tests/test_discriminate.py
@@ -127,12 +127,66 @@ def test_compute_metrics_ef1_perfect():
 
 def test_run_discrimination_missing_columns(tmp_path):
     import pandas as pd
-    # CSV missing 'cluster' column
-    bad_csv = tmp_path / "cluster_representatives.csv"
-    pd.DataFrame({'residues': ['A_1_ALA'], 'Frame': [1]}).to_csv(bad_csv, index=False)
-    actives_sdf = tmp_path / "actives.sdf"
-    actives_sdf.write_text("")
-    decoys_sdf = tmp_path / "decoys.sdf"
-    decoys_sdf.write_text("")
-    with pytest.raises(ValueError, match="missing required columns"):
-        run_discrimination(str(tmp_path), str(actives_sdf), str(decoys_sdf), str(tmp_path / "out"))
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    # Write a valid minimal SDF so SDF loading doesn't fail first
+    mol = Chem.MolFromSmiles('CCO')
+    mol = Chem.AddHs(mol)
+    AllChem.EmbedMolecule(mol, AllChem.ETKDGv3())
+    writer = Chem.SDWriter(str(tmp_path / 'actives.sdf'))
+    writer.write(mol)
+    writer.close()
+    writer2 = Chem.SDWriter(str(tmp_path / 'decoys.sdf'))
+    writer2.write(mol)
+    writer2.close()
+
+    # CSV missing 'cluster' column — should raise before scoring
+    bad_csv = tmp_path / 'cluster_representatives.csv'
+    pd.DataFrame({'residues': ['A_1_ALA A_2_ARG'], 'Frame': [1]}).to_csv(bad_csv, index=False)
+
+    with pytest.raises(ValueError, match='missing required columns'):
+        from discriminate import run_discrimination
+        run_discrimination(str(tmp_path), str(tmp_path / 'actives.sdf'),
+                           str(tmp_path / 'decoys.sdf'), str(tmp_path / 'out'))
+
+
+def test_run_discrimination_happy_path(tmp_path):
+    import pandas as pd
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    def _write_sdf(path, smiles_list):
+        writer = Chem.SDWriter(str(path))
+        for smi in smiles_list:
+            mol = Chem.MolFromSmiles(smi)
+            mol = Chem.AddHs(mol)
+            AllChem.EmbedMolecule(mol, AllChem.ETKDGv3())
+            writer.write(mol)
+        writer.close()
+
+    _write_sdf(tmp_path / 'actives.sdf', ['c1ccccc1O', 'CCN'])   # 2 actives
+    _write_sdf(tmp_path / 'decoys.sdf', ['CCCC', 'CCC', 'CC'])   # 3 decoys
+
+    reps_csv = tmp_path / 'cluster_representatives.csv'
+    pd.DataFrame({
+        'cluster': [0, 1],
+        'Frame': [10, 20],
+        'residues': ['A_1_ARG A_2_ASP A_3_PHE', 'A_4_ALA A_5_VAL A_6_LEU'],
+        'probability': [0.85, 0.72],
+    }).to_csv(reps_csv, index=False)
+
+    from discriminate import run_discrimination
+    df = run_discrimination(
+        cluster_dir=str(tmp_path),
+        actives_sdf=str(tmp_path / 'actives.sdf'),
+        decoys_sdf=str(tmp_path / 'decoys.sdf'),
+        outfolder=str(tmp_path / 'out'),
+    )
+
+    assert len(df) == 2
+    assert list(df.columns) >= ['cluster_id', 'frame', 'roc_auc', 'ef1', 'ef5']
+    assert df['roc_auc'].between(0.0, 1.0).all()
+    assert (tmp_path / 'out' / 'discrimination_results.csv').exists()
+    # Results sorted by roc_auc descending
+    assert df['roc_auc'].iloc[0] >= df['roc_auc'].iloc[1]

--- a/tests/test_discriminate.py
+++ b/tests/test_discriminate.py
@@ -75,17 +75,30 @@ def test_get_ligand_features_none_mol():
     features = get_ligand_features(None)
     assert all(v == 0 for v in features.values())
 
-def test_score_complementarity_identical_vectors():
-    pocket = {'donor': 2, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
-    ligand = {'donor': 2, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+def test_score_complementarity_hydrophobic_self_complementary():
+    # Hydrophobic is self-complementary: hydrophobic pocket scores high with hydrophobic ligand
+    pocket = {'donor': 0, 'acceptor': 0, 'hydrophobic': 3, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    ligand = {'donor': 0, 'acceptor': 0, 'hydrophobic': 2, 'aromatic': 0, 'positive': 0, 'negative': 0}
     score = score_complementarity(pocket, ligand)
     assert score == pytest.approx(1.0)
 
-def test_score_complementarity_orthogonal_vectors():
-    pocket = {'donor': 1, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
-    ligand = {'donor': 0, 'acceptor': 1, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
-    score = score_complementarity(pocket, ligand)
-    assert score == pytest.approx(0.0)
+def test_score_complementarity_hbond_cross_mapped():
+    # Pocket donor complements ligand acceptor (not donor)
+    pocket = {'donor': 2, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    ligand_acceptor = {'donor': 0, 'acceptor': 2, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    ligand_donor = {'donor': 2, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 0}
+    # Pocket donor should complement ligand acceptor
+    assert score_complementarity(pocket, ligand_acceptor) == pytest.approx(1.0)
+    # Pocket donor should NOT complement ligand donor (both donate — no pairing)
+    assert score_complementarity(pocket, ligand_donor) == pytest.approx(0.0)
+
+def test_score_complementarity_charge_cross_mapped():
+    # Pocket positive (e.g. Lys) complements ligand negative
+    pocket = {'donor': 0, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 2, 'negative': 0}
+    ligand_neg = {'donor': 0, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 0, 'negative': 2}
+    ligand_pos = {'donor': 0, 'acceptor': 0, 'hydrophobic': 0, 'aromatic': 0, 'positive': 2, 'negative': 0}
+    assert score_complementarity(pocket, ligand_neg) == pytest.approx(1.0)
+    assert score_complementarity(pocket, ligand_pos) == pytest.approx(0.0)
 
 def test_score_complementarity_zero_pocket():
     pocket = {k: 0 for k in FEATURE_KEYS}


### PR DESCRIPTION
## Summary
- Adds `discriminate.py` — residue-based pharmacophore scoring with correct complementarity (pocket donor↔ligand acceptor, pocket acceptor↔ligand donor, charge cross-mapping; hydrophobic/aromatic self-complementary)
- Adds `discriminate` CLI subcommand: ranks cluster representatives by ROC-AUC, EF1%, EF5% against user-provided actives/decoys SDF files
- 24 unit tests covering all public functions including happy-path end-to-end test

## Test Plan
- [x] 24/24 tests passing (`pytest tests/test_discriminate.py`)
- [ ] Run `python pockethunter.py discriminate --help` to verify subcommand
- [ ] Run end-to-end with real trajectory output and DUD-E actives/decoys

🤖 Generated with [Claude Code](https://claude.com/claude-code)